### PR TITLE
Fixed typo in conversation command

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -40,7 +40,7 @@ async def on_message(message):
         converse = True
         channel = message.channel.id
         return
-    if converse and message.author != client.use and channel == message.channel.id:
+    if converse and message.author != client.user and channel == message.channel.id:
         if message.content.startswith("&stop"):
             converse = False
             return


### PR DESCRIPTION
Fixed a typo in the conversation command where the bot will check the ID of itself with .use instead of .user